### PR TITLE
Pegging action version to specific minor and patch version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
 #        prerelease: true
     - name: Create a Release
       if: ${{ steps.pre_release_script.outputs.pre_release_version != '' }}
-      uses: ncipollo/release-action@v1
+      uses: ncipollo/release-action@v1.19.0
       with:
         token: ${{ inputs.release_pat }}
         tag: ${{ steps.pre_release_script.outputs.pre_release_version }}


### PR DESCRIPTION
Something something worried about supply chain attacks

This now means we'll have to manually update it when Github change stuff (and our processes break) however the author of the plugin we use pushed a new release which broke our prerelease builds, so 🤷 